### PR TITLE
fix: Fix Player Movement

### DIFF
--- a/imagine-sisyphus-happy/src/Player.ts
+++ b/imagine-sisyphus-happy/src/Player.ts
@@ -46,7 +46,7 @@ export function shiftPlayer(player: Player): Partial<Player> {
   } else if (inputState.get("ArrowRight")?.justPressed) {
     return { x: player.x + 50 };
   }
-  return player;
+  return { x: player.x };
 }
 
 export function frame(player: Player) {

--- a/imagine-sisyphus-happy/src/stateMachine.ts
+++ b/imagine-sisyphus-happy/src/stateMachine.ts
@@ -99,7 +99,7 @@ export function updateGame(
   );
   newGameState = { ...newGameState, ...judgement };
 
-  const newPlayer: Partial<Player> = gameState.player;
+  const newPlayer: Partial<Player> = {};
 
   if (judgement && judgement.elevation) {
     Object.assign(newPlayer, movePlayer(gameState.player));
@@ -110,6 +110,7 @@ export function updateGame(
     gameState.obstacles,
     gameState.expectMove,
   );
+  newGameState.player = { ...gameState.player, ...newPlayer };
 
   return newGameState;
 }


### PR DESCRIPTION
We accidentally mangled the newPlayer values and did not assign it, but we didn't catch this because we were mutably modifying gameState.player